### PR TITLE
Don't pip install gensim in test

### DIFF
--- a/recipe/forge_test.sh
+++ b/recipe/forge_test.sh
@@ -5,6 +5,4 @@ set -e -x
 unset REQUESTS_CA_BUNDLE
 unset SSL_CERT_FILE
 
-python -m pip install -U pip nose
-pip install -U gensim
 nosetests --exe -v gensim


### PR DESCRIPTION
All dependencies should be handled in meta.yaml.  pip installing stuff here is effectively not testing the code you just built.