### PR TITLE
Add OS X support

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
   number: 1
-  skip: true  # [win32 or osx]
+  skip: true  # [win32]
   script: "{{ PYTHON }} -m pip install . -vv"
 
 requirements:


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Created this to add macOS support to this feedstock. The change I have made is minor and the only thing I [could find](https://conda.io/projects/conda-build/en/latest/resources/define-metadata.html#preprocessing-selectors) that was not allowing the OS X build. I have never built / supported feedstocks before, so appreciate the help and guidance to getting this submitted.